### PR TITLE
OTA: optional password field

### DIFF
--- a/src/EspSimpleRemoteUpdate.h
+++ b/src/EspSimpleRemoteUpdate.h
@@ -77,7 +77,7 @@ public:
         }
     }
 
-    void enableOTA(const char* password, const uint16_t port = 0) {
+    void enableOTA(const char* password = NULL, const uint16_t port = 0) {
         if(_enableDebugMessages)
             Serial.printf("UPDATER: Enabling Arduino OTA ...\n");
 


### PR DESCRIPTION
Allows to omit the password field. Currently I have to set `NULL` in order to use it.

Like it is here:

https://github.com/plapointe6/EspMQTTClient/blob/bd829e1352bc970b6fa6a99c7243d9205e2ef700/src/EspMQTTClient.h#L142